### PR TITLE
Implement basic map SPA

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,10 +11,23 @@ html,body{height:100%;margin:0;}
 .tab-buttons button{margin-right:5px;}
 #memoDialog{position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);background:#fff;padding:10px;border:1px solid #666;z-index:2000;display:none;}
 .leaflet-div-icon.pin{
-  width:20px;
-  height:20px;
+  position:relative;
+  width:24px;
+  height:24px;
   background:currentColor;
+  border-radius:50% 50% 50% 0;
+  transform:rotate(-45deg);
+}
+.leaflet-div-icon.pin::after{
+  content:'';
+  position:absolute;
+  top:50%;
+  left:50%;
+  width:12px;
+  height:12px;
+  background:#fff;
   border-radius:50%;
+  transform:translate(-50%,-50%) rotate(45deg);
 }
 .pin-restaurant{background:#FFC90E;color:#FFC90E;}
 .pin-historic{background:#F02DFF;color:#F02DFF;}
@@ -59,7 +72,7 @@ const memoSave=document.getElementById('memoSave');
 const memoCancel=document.getElementById('memoCancel');
 let currentCoord=null,currentType=null;
 const memoStore=JSON.parse(localStorage.getItem('memoStore')||'{}');
-const iconOpts={iconSize:[20,20],iconAnchor:[10,10]};
+const iconOpts={iconSize:[24,24],iconAnchor:[12,24]};
 const icons={
   restaurant:L.divIcon({...iconOpts,className:'leaflet-div-icon pin pin-restaurant'}),
   historic:L.divIcon({...iconOpts,className:'leaflet-div-icon pin pin-historic'}),

--- a/index.html
+++ b/index.html
@@ -129,9 +129,7 @@ function loadRestaurants(){overpassQuery('node["amenity"~"restaurant|cafe|fast_f
 function loadHistoric(){overpassQuery('node["historic"]',layers.historic,icons.historic);}
 function loadArt(){overpassQuery('node["tourism"="artwork"]',layers.art,icons.art);}
 function loadShelter(){
-  const b=map.getBounds();
-  const bbox=`${b.getSouth()},${b.getWest()},${b.getNorth()},${b.getEast()}`;
-  const url=`https://wapi.bodik.jp/api/3/action/datastore_search?resource_id=4829da84-5cb4-46d5-a6b0-0130359da105&bbox=${bbox}&limit=10000`;
+  const url='https://wapi.bodik.jp/api/3/action/datastore_search?resource_id=4829da84-5cb4-46d5-a6b0-0130359da105&limit=10000';
   console.log('Shelter API:',url);
   jsonp(url).then(j=>{
     layers.shelter.clearLayers();

--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@ html,body{height:100%;margin:0;}
   height:24px;
   background:none;
   border:none;
+  overflow:visible;
 }
 .leaflet-div-icon.pin svg{
   display:block;
@@ -68,7 +69,7 @@ const memoSave=document.getElementById('memoSave');
 const memoCancel=document.getElementById('memoCancel');
 let currentCoord=null,currentType=null;
 const memoStore=JSON.parse(localStorage.getItem('memoStore')||'{}');
-const pinSvg='<svg viewBox="0 0 24 24" width="24" height="24">'+
+const pinSvg='<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">'+
   '<path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7z" fill="currentColor"/>'+
   '<circle cx="12" cy="9" r="3" fill="white"/></svg>';
 const iconOpts={iconSize:[24,24],iconAnchor:[12,24]};

--- a/index.html
+++ b/index.html
@@ -10,8 +10,12 @@ html,body{height:100%;margin:0;}
 #menu{position:absolute;top:10px;right:10px;width:200px;background:rgba(255,255,255,0.9);padding:10px;overflow-y:auto;border-radius:4px;box-shadow:0 0 5px rgba(0,0,0,0.3);z-index:1000;}
 .tab-buttons button{margin-right:5px;}
 #memoDialog{position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);background:#fff;padding:10px;border:1px solid #666;z-index:2000;display:none;}
-.leaflet-div-icon.pin{width:24px;height:24px;background:currentColor;border-radius:50% 50% 50% 0;transform:rotate(-45deg);position:relative;}
-.leaflet-div-icon.pin:after{content:"";position:absolute;width:12px;height:12px;background:#fff;border-radius:50%;left:6px;top:6px;}
+.leaflet-div-icon.pin{
+  width:20px;
+  height:20px;
+  background:currentColor;
+  border-radius:50%;
+}
 .pin-restaurant{background:#FFC90E;color:#FFC90E;}
 .pin-historic{background:#F02DFF;color:#F02DFF;}
 .pin-art{background:#1BFF7A;color:#1BFF7A;}
@@ -55,7 +59,7 @@ const memoSave=document.getElementById('memoSave');
 const memoCancel=document.getElementById('memoCancel');
 let currentCoord=null,currentType=null;
 const memoStore=JSON.parse(localStorage.getItem('memoStore')||'{}');
-const iconOpts={iconSize:[24,24],iconAnchor:[12,24]};
+const iconOpts={iconSize:[20,20],iconAnchor:[10,10]};
 const icons={
   restaurant:L.divIcon({...iconOpts,className:'pin pin-restaurant'}),
   historic:L.divIcon({...iconOpts,className:'pin pin-historic'}),

--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@ html,body{height:100%;margin:0;}
 .leaflet-div-icon.pin svg{
   display:block;
   transform-origin:50% 100%;
-  transform:rotate(-45deg);
+  transform:none;
 }
 .pin-restaurant{color:#FFC90E;}
 .pin-historic{color:#F02DFF;}

--- a/index.html
+++ b/index.html
@@ -53,6 +53,7 @@ html,body{height:100%;margin:0;}
   <button id="resetView">リセット</button>
 </div>
 <div id="memoDialog">
+  <div id="memoName" style="margin-bottom:4px;font-weight:bold;"></div>
   <textarea id="memoText" rows="4" cols="30"></textarea><br>
   <button id="memoSave">保存</button>
   <button id="memoCancel">キャンセル</button>
@@ -65,10 +66,11 @@ const savedView=JSON.parse(localStorage.getItem('startView'))||defaultView;
 const map=L.map('map').setView([savedView.lat,savedView.lng],savedView.zoom);
 L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',{maxZoom:19,attribution:'&copy; OpenStreetMap contributors'}).addTo(map);
 const memoDialog=document.getElementById('memoDialog');
+const memoName=document.getElementById('memoName');
 const memoText=document.getElementById('memoText');
 const memoSave=document.getElementById('memoSave');
 const memoCancel=document.getElementById('memoCancel');
-let currentCoord=null,currentType=null;
+let currentCoord=null,currentType=null,currentName='';
 const memoStore=JSON.parse(localStorage.getItem('memoStore')||'{}');
 const pinSvg='<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">'+
   '<path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7z" fill="currentColor"/>'+
@@ -106,7 +108,8 @@ function overpassQuery(query,layer,icon){
     layer.clearLayers();
     d.elements.forEach(el=>{
       const lat=el.lat||el.center.lat;const lon=el.lon||el.center.lon;
-      const m=L.marker([lat,lon],{icon:icon}).on('click',()=>openMemo([lat,lon]));
+      const name=el.tags&&el.tags.name?el.tags.name:'';
+      const m=L.marker([lat,lon],{icon:icon}).on('click',()=>openMemo([lat,lon],name));
       layer.addLayer(m);
     });
   }).catch(()=>{});
@@ -120,17 +123,20 @@ function loadShelter(){
   const ne=b.getNorthEast();
   const bbox=`${sw.lng},${sw.lat},${ne.lng},${ne.lat}`;
   const url='https://wapi.bodik.jp/api/v1/shelter.geojson?bbox='+bbox;
-  fetch(url).then(r=>r.json()).then(j=>{
+  fetch(url).then(r=>{console.log('Shelter API:',url);return r.json();}).then(j=>{
     layers.shelter.clearLayers();
     j.features.forEach(f=>{
       const c=f.geometry.coordinates;const lat=c[1],lon=c[0];
-      const m=L.marker([lat,lon],{icon:icons.shelter}).on('click',()=>openMemo([lat,lon]));
+      const name=f.properties&& (f.properties.name||f.properties['\u540d\u79f0'])? (f.properties.name||f.properties['\u540d\u79f0']) : '';
+      const m=L.marker([lat,lon],{icon:icons.shelter}).on('click',()=>openMemo([lat,lon],name));
       layers.shelter.addLayer(m);
     });
   }).catch(()=>{});
 }
-function openMemo(coord){
+function openMemo(coord,name){
   currentCoord=coord;
+  currentName=name||'';
+  memoName.textContent=currentName;
   memoText.value=memoStore[coord.join(',')]||'';
   memoDialog.style.display='block';
 }

--- a/index.html
+++ b/index.html
@@ -61,11 +61,11 @@ let currentCoord=null,currentType=null;
 const memoStore=JSON.parse(localStorage.getItem('memoStore')||'{}');
 const iconOpts={iconSize:[20,20],iconAnchor:[10,10]};
 const icons={
-  restaurant:L.divIcon({...iconOpts,className:'pin pin-restaurant'}),
-  historic:L.divIcon({...iconOpts,className:'pin pin-historic'}),
-  art:L.divIcon({...iconOpts,className:'pin pin-art'}),
-  shelter:L.divIcon({...iconOpts,className:'pin pin-shelter'}),
-  memo:L.divIcon({...iconOpts,className:'pin pin-memo'})
+  restaurant:L.divIcon({...iconOpts,className:'leaflet-div-icon pin pin-restaurant'}),
+  historic:L.divIcon({...iconOpts,className:'leaflet-div-icon pin pin-historic'}),
+  art:L.divIcon({...iconOpts,className:'leaflet-div-icon pin pin-art'}),
+  shelter:L.divIcon({...iconOpts,className:'leaflet-div-icon pin pin-shelter'}),
+  memo:L.divIcon({...iconOpts,className:'leaflet-div-icon pin pin-memo'})
 };
 const layers={
   restaurant:L.layerGroup().addTo(map),

--- a/index.html
+++ b/index.html
@@ -129,7 +129,9 @@ function loadRestaurants(){overpassQuery('node["amenity"~"restaurant|cafe|fast_f
 function loadHistoric(){overpassQuery('node["historic"]',layers.historic,icons.historic);}
 function loadArt(){overpassQuery('node["tourism"="artwork"]',layers.art,icons.art);}
 function loadShelter(){
-  const url='https://data.bodik.jp/api/3/action/datastore_search?resource_id=4829da84-5cb4-46d5-a6b0-0130359da105&limit=10000';
+  const b=map.getBounds();
+  const bbox=`${b.getSouth()},${b.getWest()},${b.getNorth()},${b.getEast()}`;
+  const url=`https://wapi.bodik.jp/api/3/action/datastore_search?resource_id=4829da84-5cb4-46d5-a6b0-0130359da105&bbox=${bbox}&limit=10000`;
   console.log('Shelter API:',url);
   jsonp(url).then(j=>{
     layers.shelter.clearLayers();

--- a/index.html
+++ b/index.html
@@ -7,7 +7,8 @@
 <style>
 html,body{height:100%;margin:0;}
 #map{position:absolute;top:0;bottom:0;left:0;right:0;}
-#menu{position:absolute;top:10px;right:10px;width:200px;background:rgba(255,255,255,0.9);padding:10px;overflow-y:auto;border-radius:4px;box-shadow:0 0 5px rgba(0,0,0,0.3);z-index:1000;}
+#modeSwitch{position:absolute;top:10px;left:10px;background:rgba(255,255,255,0.9);padding:5px;border-radius:4px;box-shadow:0 0 5px rgba(0,0,0,0.3);z-index:1000;}
+#menu{position:absolute;top:60px;left:10px;width:200px;background:rgba(255,255,255,0.9);padding:10px;overflow-y:auto;border-radius:4px;box-shadow:0 0 5px rgba(0,0,0,0.3);z-index:1000;}
 .tab-buttons button{margin-right:5px;}
 #memoDialog{position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);background:#fff;padding:10px;border:1px solid #666;z-index:2000;display:none;}
 .leaflet-div-icon.pin{
@@ -35,11 +36,11 @@ html,body{height:100%;margin:0;}
 </head>
 <body>
 <div id="map"></div>
+<div id="modeSwitch" class="tab-buttons">
+  <button id="tourismTab">観光モード</button>
+  <button id="evacTab">避難モード</button>
+</div>
 <div id="menu">
-  <div class="tab-buttons">
-    <button id="tourismTab">観光モード</button>
-    <button id="evacTab">避難モード</button>
-  </div>
   <div id="tourismMenu">
     <label><input type="checkbox" id="chkRestaurant" checked><span style="color:#FFC90E">飲食店</span></label><br>
     <label><input type="checkbox" id="chkHistoric" checked><span style="color:#F02DFF">史跡</span></label><br>

--- a/index.html
+++ b/index.html
@@ -34,6 +34,10 @@ html,body{height:100%;margin:0;}
 .pin-art{background:#1BFF7A;color:#1BFF7A;}
 .pin-shelter{background:#FF0000;color:#FF0000;}
 .pin-memo{background:#00C8FF;color:#00C8FF;}
+#chkRestaurant{accent-color:#FFC90E;}
+#chkHistoric{accent-color:#F02DFF;}
+#chkArt{accent-color:#1BFF7A;}
+#chkShelter{accent-color:#FF0000;}
 </style>
 </head>
 <body>

--- a/index.html
+++ b/index.html
@@ -11,29 +11,21 @@ html,body{height:100%;margin:0;}
 .tab-buttons button{margin-right:5px;}
 #memoDialog{position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);background:#fff;padding:10px;border:1px solid #666;z-index:2000;display:none;}
 .leaflet-div-icon.pin{
-  position:relative;
   width:24px;
   height:24px;
-  background:currentColor;
-  border-radius:50% 50% 50% 0;
-  transform:rotate(-90deg);
+  background:none;
+  border:none;
 }
-.leaflet-div-icon.pin::after{
-  content:'';
-  position:absolute;
-  top:50%;
-  left:50%;
-  width:12px;
-  height:12px;
-  background:#fff;
-  border-radius:50%;
-  transform:translate(-50%,-50%) rotate(90deg);
+.leaflet-div-icon.pin svg{
+  display:block;
+  transform-origin:50% 100%;
+  transform:rotate(-45deg);
 }
-.pin-restaurant{background:#FFC90E;color:#FFC90E;}
-.pin-historic{background:#F02DFF;color:#F02DFF;}
-.pin-art{background:#1BFF7A;color:#1BFF7A;}
-.pin-shelter{background:#FF0000;color:#FF0000;}
-.pin-memo{background:#00C8FF;color:#00C8FF;}
+.pin-restaurant{color:#FFC90E;}
+.pin-historic{color:#F02DFF;}
+.pin-art{color:#1BFF7A;}
+.pin-shelter{color:#FF0000;}
+.pin-memo{color:#00C8FF;}
 #chkRestaurant{accent-color:#FFC90E;}
 #chkHistoric{accent-color:#F02DFF;}
 #chkArt{accent-color:#1BFF7A;}
@@ -76,13 +68,16 @@ const memoSave=document.getElementById('memoSave');
 const memoCancel=document.getElementById('memoCancel');
 let currentCoord=null,currentType=null;
 const memoStore=JSON.parse(localStorage.getItem('memoStore')||'{}');
+const pinSvg='<svg viewBox="0 0 24 24" width="24" height="24">'+
+  '<path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7z" fill="currentColor"/>'+
+  '<circle cx="12" cy="9" r="3" fill="white"/></svg>';
 const iconOpts={iconSize:[24,24],iconAnchor:[12,24]};
 const icons={
-  restaurant:L.divIcon({...iconOpts,className:'leaflet-div-icon pin pin-restaurant'}),
-  historic:L.divIcon({...iconOpts,className:'leaflet-div-icon pin pin-historic'}),
-  art:L.divIcon({...iconOpts,className:'leaflet-div-icon pin pin-art'}),
-  shelter:L.divIcon({...iconOpts,className:'leaflet-div-icon pin pin-shelter'}),
-  memo:L.divIcon({...iconOpts,className:'leaflet-div-icon pin pin-memo'})
+  restaurant:L.divIcon({...iconOpts,html:pinSvg,className:'leaflet-div-icon pin pin-restaurant'}),
+  historic:L.divIcon({...iconOpts,html:pinSvg,className:'leaflet-div-icon pin pin-historic'}),
+  art:L.divIcon({...iconOpts,html:pinSvg,className:'leaflet-div-icon pin pin-art'}),
+  shelter:L.divIcon({...iconOpts,html:pinSvg,className:'leaflet-div-icon pin pin-shelter'}),
+  memo:L.divIcon({...iconOpts,html:pinSvg,className:'leaflet-div-icon pin pin-memo'})
 };
 const layers={
   restaurant:L.layerGroup().addTo(map),

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@ html,body{height:100%;margin:0;}
   height:24px;
   background:currentColor;
   border-radius:50% 50% 50% 0;
-  transform:rotate(-45deg);
+  transform:rotate(-90deg);
 }
 .leaflet-div-icon.pin::after{
   content:'';
@@ -27,7 +27,7 @@ html,body{height:100%;margin:0;}
   height:12px;
   background:#fff;
   border-radius:50%;
-  transform:translate(-50%,-50%) rotate(45deg);
+  transform:translate(-50%,-50%) rotate(90deg);
 }
 .pin-restaurant{background:#FFC90E;color:#FFC90E;}
 .pin-historic{background:#F02DFF;color:#F02DFF;}

--- a/index.html
+++ b/index.html
@@ -10,8 +10,8 @@ html,body{height:100%;margin:0;}
 #menu{position:absolute;top:10px;right:10px;width:200px;background:rgba(255,255,255,0.9);padding:10px;overflow-y:auto;border-radius:4px;box-shadow:0 0 5px rgba(0,0,0,0.3);z-index:1000;}
 .tab-buttons button{margin-right:5px;}
 #memoDialog{position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);background:#fff;padding:10px;border:1px solid #666;z-index:2000;display:none;}
-.leaflet-div-icon.pin{width:20px;height:20px;background:currentColor;border-radius:50% 50% 50% 0;transform:rotate(-45deg);position:relative;border:2px solid #fff;}
-.leaflet-div-icon.pin:after{content:"";position:absolute;width:8px;height:8px;background:#fff;border-radius:50%;left:50%;top:50%;margin:-4px 0 0 -4px;}
+.leaflet-div-icon.pin{width:24px;height:24px;background:currentColor;border-radius:50% 50% 50% 0;transform:rotate(-45deg);position:relative;}
+.leaflet-div-icon.pin:after{content:"";position:absolute;width:12px;height:12px;background:#fff;border-radius:50%;left:6px;top:6px;}
 .pin-restaurant{background:#FFC90E;color:#FFC90E;}
 .pin-historic{background:#F02DFF;color:#F02DFF;}
 .pin-art{background:#1BFF7A;color:#1BFF7A;}
@@ -55,12 +55,13 @@ const memoSave=document.getElementById('memoSave');
 const memoCancel=document.getElementById('memoCancel');
 let currentCoord=null,currentType=null;
 const memoStore=JSON.parse(localStorage.getItem('memoStore')||'{}');
+const iconOpts={iconSize:[24,24],iconAnchor:[12,24]};
 const icons={
-  restaurant:L.divIcon({className:'pin pin-restaurant'}),
-  historic:L.divIcon({className:'pin pin-historic'}),
-  art:L.divIcon({className:'pin pin-art'}),
-  shelter:L.divIcon({className:'pin pin-shelter'}),
-  memo:L.divIcon({className:'pin pin-memo'})
+  restaurant:L.divIcon({...iconOpts,className:'pin pin-restaurant'}),
+  historic:L.divIcon({...iconOpts,className:'pin pin-historic'}),
+  art:L.divIcon({...iconOpts,className:'pin pin-art'}),
+  shelter:L.divIcon({...iconOpts,className:'pin pin-shelter'}),
+  memo:L.divIcon({...iconOpts,className:'pin pin-memo'})
 };
 const layers={
   restaurant:L.layerGroup().addTo(map),

--- a/index.html
+++ b/index.html
@@ -1,0 +1,207 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<title>Mojiko Map</title>
+<link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"/>
+<style>
+html,body{height:100%;margin:0;}
+#map{position:absolute;top:0;bottom:0;left:0;right:0;}
+#menu{position:absolute;top:10px;right:10px;width:200px;background:rgba(255,255,255,0.9);padding:10px;overflow-y:auto;border-radius:4px;box-shadow:0 0 5px rgba(0,0,0,0.3);z-index:1000;}
+.tab-buttons button{margin-right:5px;}
+#memoDialog{position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);background:#fff;padding:10px;border:1px solid #666;z-index:2000;display:none;}
+.leaflet-div-icon.pin{width:20px;height:20px;background:currentColor;border-radius:50% 50% 50% 0;transform:rotate(-45deg);position:relative;border:2px solid #fff;}
+.leaflet-div-icon.pin:after{content:"";position:absolute;width:8px;height:8px;background:#fff;border-radius:50%;left:50%;top:50%;margin:-4px 0 0 -4px;}
+.pin-restaurant{background:#FFC90E;color:#FFC90E;}
+.pin-historic{background:#F02DFF;color:#F02DFF;}
+.pin-art{background:#1BFF7A;color:#1BFF7A;}
+.pin-shelter{background:#FF0000;color:#FF0000;}
+.pin-memo{background:#00C8FF;color:#00C8FF;}
+</style>
+</head>
+<body>
+<div id="map"></div>
+<div id="menu">
+  <div class="tab-buttons">
+    <button id="tourismTab">観光モード</button>
+    <button id="evacTab">避難モード</button>
+  </div>
+  <div id="tourismMenu">
+    <label><input type="checkbox" id="chkRestaurant" checked><span style="color:#FFC90E">飲食店</span></label><br>
+    <label><input type="checkbox" id="chkHistoric" checked><span style="color:#F02DFF">史跡</span></label><br>
+    <label><input type="checkbox" id="chkArt" checked><span style="color:#1BFF7A">アート</span></label>
+  </div>
+  <div id="evacMenu" style="display:none;">
+    <label><input type="checkbox" id="chkShelter" checked><span style="color:#FF0000">指定避難場所</span></label>
+  </div>
+  <button id="saveView">初期位置にする</button>
+  <button id="resetView">リセット</button>
+</div>
+<div id="memoDialog">
+  <textarea id="memoText" rows="4" cols="30"></textarea><br>
+  <button id="memoSave">保存</button>
+  <button id="memoCancel">キャンセル</button>
+</div>
+<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+<script>
+(function(){
+const defaultView={lat:33.948,lng:130.96,zoom:15};
+const savedView=JSON.parse(localStorage.getItem('startView'))||defaultView;
+const map=L.map('map').setView([savedView.lat,savedView.lng],savedView.zoom);
+L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',{maxZoom:19,attribution:'&copy; OpenStreetMap contributors'}).addTo(map);
+const memoDialog=document.getElementById('memoDialog');
+const memoText=document.getElementById('memoText');
+const memoSave=document.getElementById('memoSave');
+const memoCancel=document.getElementById('memoCancel');
+let currentCoord=null,currentType=null;
+const memoStore=JSON.parse(localStorage.getItem('memoStore')||'{}');
+const icons={
+  restaurant:L.divIcon({className:'pin pin-restaurant'}),
+  historic:L.divIcon({className:'pin pin-historic'}),
+  art:L.divIcon({className:'pin pin-art'}),
+  shelter:L.divIcon({className:'pin pin-shelter'}),
+  memo:L.divIcon({className:'pin pin-memo'})
+};
+const layers={
+  restaurant:L.layerGroup().addTo(map),
+  historic:L.layerGroup().addTo(map),
+  art:L.layerGroup().addTo(map),
+  shelter:L.layerGroup().addTo(map),
+  memo:L.layerGroup().addTo(map),
+  route:L.polyline([],{color:'red',weight:5})
+};
+map.on('moveend',updatePOIs);
+function updatePOIs(){
+  if(document.getElementById('chkRestaurant').checked && tourismActive()) loadRestaurants();
+  if(document.getElementById('chkHistoric').checked && tourismActive()) loadHistoric();
+  if(document.getElementById('chkArt').checked && tourismActive()) loadArt();
+  if(document.getElementById('chkShelter').checked && evacActive()) loadShelter();
+}
+function tourismActive(){return document.getElementById('tourismMenu').style.display!=='none';}
+function evacActive(){return document.getElementById('evacMenu').style.display!=='none';}
+function overpassQuery(query,layer,icon){
+  const b=map.getBounds();
+  const bbox=`${b.getSouth()},${b.getWest()},${b.getNorth()},${b.getEast()}`;
+  const url='https://overpass-api.de/api/interpreter?data='+encodeURIComponent(`[out:json];${query}( ${bbox} );out center;`);
+  fetch(url).then(r=>r.json()).then(d=>{
+    layer.clearLayers();
+    d.elements.forEach(el=>{
+      const lat=el.lat||el.center.lat;const lon=el.lon||el.center.lon;
+      const m=L.marker([lat,lon],{icon:icon}).on('click',()=>openMemo([lat,lon]));
+      layer.addLayer(m);
+    });
+  }).catch(()=>{});
+}
+function loadRestaurants(){overpassQuery('node["amenity"~"restaurant|cafe|fast_food|bar"]',layers.restaurant,icons.restaurant);}
+function loadHistoric(){overpassQuery('node["historic"]',layers.historic,icons.historic);}
+function loadArt(){overpassQuery('node["tourism"="artwork"]',layers.art,icons.art);}
+function loadShelter(){
+  const b=map.getBounds();
+  const sw=b.getSouthWest();
+  const ne=b.getNorthEast();
+  const bbox=`${sw.lng},${sw.lat},${ne.lng},${ne.lat}`;
+  const url='https://wapi.bodik.jp/api/v1/shelter.geojson?bbox='+bbox;
+  fetch(url).then(r=>r.json()).then(j=>{
+    layers.shelter.clearLayers();
+    j.features.forEach(f=>{
+      const c=f.geometry.coordinates;const lat=c[1],lon=c[0];
+      const m=L.marker([lat,lon],{icon:icons.shelter}).on('click',()=>openMemo([lat,lon]));
+      layers.shelter.addLayer(m);
+    });
+  }).catch(()=>{});
+}
+function openMemo(coord){
+  currentCoord=coord;
+  memoText.value=memoStore[coord.join(',')]||'';
+  memoDialog.style.display='block';
+}
+memoSave.onclick=function(){
+  if(currentCoord){
+    memoStore[currentCoord.join(',')]=memoText.value;
+    localStorage.setItem('memoStore',JSON.stringify(memoStore));
+    let existing=null;
+    layers.memo.eachLayer(l=>{if(l.getLatLng().lat===currentCoord[0]&&l.getLatLng().lng===currentCoord[1]) existing=l;});
+    if(!existing){
+      const m=L.marker(currentCoord,{icon:icons.memo}).on('click',()=>alert(memoStore[currentCoord.join(',')]||''));
+      layers.memo.addLayer(m);
+    }
+  }
+  memoDialog.style.display='none';
+};
+memoCancel.onclick=function(){memoDialog.style.display='none';};
+map.on('click',function(e){
+  const latlng=[e.latlng.lat,e.latlng.lng];
+  let clickedMarker=false;
+  map.eachLayer(l=>{if(l instanceof L.Marker&&l.getLatLng().equals(e.latlng))clickedMarker=true;});
+  if(clickedMarker)return;
+  if(tourismActive()){
+    openMemo(latlng);
+  }else if(evacActive()){
+    if(!layers.shelter.getLayers().length)return;
+    let nearest=null,dist=Infinity;
+    layers.shelter.eachLayer(l=>{
+      const d=map.distance(e.latlng,l.getLatLng());
+      if(d<dist){dist=d;nearest=l;}
+    });
+    if(nearest){
+      layers.route.setLatLngs([e.latlng,nearest.getLatLng()]).addTo(map);
+    }
+  }
+});
+updatePOIs();
+function restoreMemos(){
+  Object.keys(memoStore).forEach(k=>{
+    const p=k.split(',').map(Number);
+    const m=L.marker(p,{icon:icons.memo}).on('click',()=>alert(memoStore[k]||''));
+    layers.memo.addLayer(m);
+  });
+}
+restoreMemos();
+// checkbox events
+['chkRestaurant','chkHistoric','chkArt'].forEach(id=>{
+ document.getElementById(id).addEventListener('change',function(){
+   const layer=layers[id.replace('chk','').toLowerCase()];
+   if(this.checked){map.addLayer(layer);loadPOIbyId(id);}else map.removeLayer(layer);
+ });
+});
+document.getElementById('chkShelter').addEventListener('change',function(){
+  if(this.checked){map.addLayer(layers.shelter);loadShelter();}else map.removeLayer(layers.shelter);
+});
+function loadPOIbyId(id){if(id==='chkRestaurant')loadRestaurants();if(id==='chkHistoric')loadHistoric();if(id==='chkArt')loadArt();}
+// tab events
+const tourismTab=document.getElementById('tourismTab');
+const evacTab=document.getElementById('evacTab');
+tourismTab.onclick=function(){
+  document.getElementById('tourismMenu').style.display='block';
+  document.getElementById('evacMenu').style.display='none';
+  map.removeLayer(layers.route);
+  if(document.getElementById('chkShelter').checked) map.removeLayer(layers.shelter);
+  if(document.getElementById('chkRestaurant').checked) map.addLayer(layers.restaurant);
+  if(document.getElementById('chkHistoric').checked) map.addLayer(layers.historic);
+  if(document.getElementById('chkArt').checked) map.addLayer(layers.art);
+  updatePOIs();
+};
+evacTab.onclick=function(){
+  document.getElementById('tourismMenu').style.display='none';
+  document.getElementById('evacMenu').style.display='block';
+  map.removeLayer(layers.restaurant);
+  map.removeLayer(layers.historic);
+  map.removeLayer(layers.art);
+  if(document.getElementById('chkShelter').checked) map.addLayer(layers.shelter); else map.removeLayer(layers.shelter);
+  updatePOIs();
+};
+// initial tab: tourism
+tourismTab.click();
+// buttons
+ document.getElementById('saveView').onclick=function(){
+   const c=map.getCenter();
+   localStorage.setItem('startView',JSON.stringify({lat:c.lat,lng:c.lng,zoom:map.getZoom()}));
+ };
+ document.getElementById('resetView').onclick=function(){
+   localStorage.removeItem('startView');
+   map.setView([defaultView.lat,defaultView.lng],defaultView.zoom);
+ };
+})();
+</script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -129,7 +129,7 @@ function loadRestaurants(){overpassQuery('node["amenity"~"restaurant|cafe|fast_f
 function loadHistoric(){overpassQuery('node["historic"]',layers.historic,icons.historic);}
 function loadArt(){overpassQuery('node["tourism"="artwork"]',layers.art,icons.art);}
 function loadShelter(){
-  const url='https://wapi.bodik.jp/api/3/action/datastore_search?resource_id=4829da84-5cb4-46d5-a6b0-0130359da105&limit=10000';
+  const url='https://data.bodik.jp/api/3/action/datastore_search?resource_id=4829da84-5cb4-46d5-a6b0-0130359da105&limit=10000';
   console.log('Shelter API:',url);
   jsonp(url).then(j=>{
     layers.shelter.clearLayers();

--- a/index.html
+++ b/index.html
@@ -118,16 +118,15 @@ function loadRestaurants(){overpassQuery('node["amenity"~"restaurant|cafe|fast_f
 function loadHistoric(){overpassQuery('node["historic"]',layers.historic,icons.historic);}
 function loadArt(){overpassQuery('node["tourism"="artwork"]',layers.art,icons.art);}
 function loadShelter(){
-  const b=map.getBounds();
-  const sw=b.getSouthWest();
-  const ne=b.getNorthEast();
-  const bbox=`${sw.lng},${sw.lat},${ne.lng},${ne.lat}`;
-  const url='https://wapi.bodik.jp/api/v1/shelter.geojson?bbox='+bbox;
+  const url='https://data.bodik.jp/api/3/action/datastore_search?resource_id=4829da84-5cb4-46d5-a6b0-0130359da105&limit=10000';
   fetch(url).then(r=>{console.log('Shelter API:',url);return r.json();}).then(j=>{
     layers.shelter.clearLayers();
-    j.features.forEach(f=>{
-      const c=f.geometry.coordinates;const lat=c[1],lon=c[0];
-      const name=f.properties&& (f.properties.name||f.properties['\u540d\u79f0'])? (f.properties.name||f.properties['\u540d\u79f0']) : '';
+    const recs=(j.result&&j.result.records)||[];
+    recs.forEach(rec=>{
+      const lat=parseFloat(rec.lat||rec.latitude||rec['\u7def\u5ea6']||rec['\u7def\u5ea6(\u5343\u5206\u7def)']||rec['\u7def\u5ea6(\u5ea7\u6a19)']||(rec.geometry&&rec.geometry.coordinates[1]));
+      const lon=parseFloat(rec.lon||rec.longitude||rec['\u7d4c\u5ea6']||rec['\u7d4c\u5ea6(\u5343\u5206\u7def)']||rec['\u7d4c\u5ea6(\u5ea7\u6a19)']||(rec.geometry&&rec.geometry.coordinates[0]));
+      if(isNaN(lat)||isNaN(lon))return;
+      const name=rec.name||rec['\u540d\u79f0']||'';
       const m=L.marker([lat,lon],{icon:icons.shelter}).on('click',()=>openMemo([lat,lon],name));
       layers.shelter.addLayer(m);
     });

--- a/index.html
+++ b/index.html
@@ -114,12 +114,24 @@ function overpassQuery(query,layer,icon){
     });
   }).catch(()=>{});
 }
+function jsonp(url){
+  return new Promise((resolve,reject)=>{
+    const cb='cb'+Math.random().toString(36).slice(2);
+    const script=document.createElement('script');
+    script.src=url+(url.includes('?')?'&':'?')+'callback='+cb;
+    window[cb]=data=>{resolve(data);cleanup();};
+    script.onerror=()=>{reject(new Error('JSONP failed'));cleanup();};
+    function cleanup(){delete window[cb];script.remove();}
+    document.head.appendChild(script);
+  });
+}
 function loadRestaurants(){overpassQuery('node["amenity"~"restaurant|cafe|fast_food|bar"]',layers.restaurant,icons.restaurant);}
 function loadHistoric(){overpassQuery('node["historic"]',layers.historic,icons.historic);}
 function loadArt(){overpassQuery('node["tourism"="artwork"]',layers.art,icons.art);}
 function loadShelter(){
   const url='https://data.bodik.jp/api/3/action/datastore_search?resource_id=4829da84-5cb4-46d5-a6b0-0130359da105&limit=10000';
-  fetch(url).then(r=>{console.log('Shelter API:',url);return r.json();}).then(j=>{
+  console.log('Shelter API:',url);
+  jsonp(url).then(j=>{
     layers.shelter.clearLayers();
     const recs=(j.result&&j.result.records)||[];
     recs.forEach(rec=>{

--- a/index.html
+++ b/index.html
@@ -182,7 +182,16 @@ map.on('click',function(e){
       if(d<dist){dist=d;nearest=l;}
     });
     if(nearest){
-      layers.route.setLatLngs([e.latlng,nearest.getLatLng()]).addTo(map);
+      const from=e.latlng;
+      const to=nearest.getLatLng();
+      const rurl=`https://router.project-osrm.org/route/v1/foot/${from.lng},${from.lat};${to.lng},${to.lat}?overview=full&geometries=geojson`;
+      console.log('Route API:',rurl);
+      fetch(rurl).then(r=>r.json()).then(d=>{
+        const coords=d.routes[0].geometry.coordinates.map(c=>[c[1],c[0]]);
+        layers.route.setLatLngs(coords).addTo(map);
+      }).catch(()=>{
+        layers.route.setLatLngs([from,to]).addTo(map);
+      });
     }
   }
 });


### PR DESCRIPTION
## Summary
- add a single `index.html` implementing a simple SPA
- include Leaflet map with OpenStreetMap tiles
- show restaurants, historic sites, art and shelters with colored markers
- enable memos stored in localStorage and route display to nearest shelter
- allow toggling layers and saving the start view
- update marker style to teardrop pins and overlay the menu
- fix shelter bounding box order
- use latest BODIK API without region specification
- switch to marker pin style icons
- update marker shape to inverted droplet

## Testing
- `git log -1 --stat`
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684bcea7258c8332a328aa1057bede89